### PR TITLE
Add linter tests to all packages

### DIFF
--- a/confbot_bringup/CMakeLists.txt
+++ b/confbot_bringup/CMakeLists.txt
@@ -7,4 +7,9 @@ find_package(ament_cmake REQUIRED)
 install(DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/confbot_driver/CMakeLists.txt
+++ b/confbot_driver/CMakeLists.txt
@@ -56,4 +56,9 @@ install(
   TARGETS confbot_driver twist_publisher confbot_all
   DESTINATION lib/${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/confbot_driver/include/confbot_driver/confbot_driver.hpp
+++ b/confbot_driver/include/confbot_driver/confbot_driver.hpp
@@ -1,3 +1,17 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONFBOT_DRIVER__CONFBOT_DRIVER_HPP_
 #define CONFBOT_DRIVER__CONFBOT_DRIVER_HPP_
 
@@ -46,7 +60,7 @@ struct RobotPosition
 class ConfbotDriver : public rclcpp::Node
 {
 public:
-  explicit ConfbotDriver()
+  ConfbotDriver()
   : Node("confbot_driver")
   {}
 
@@ -64,7 +78,8 @@ public:
       "cmd_vel", std::bind(&ConfbotDriver::update_position, this, std::placeholders::_1));
   }
 
-  void update_odometry() {
+  void update_odometry()
+  {
     robot_position_.heading += vel_ang_;
     robot_position_.x += 2.0 * cos(robot_position_.heading) * vel_lin_;
     robot_position_.y += 2.0 * sin(robot_position_.heading) * vel_lin_;
@@ -80,7 +95,6 @@ public:
   }
 
 private:
-
   float vel_lin_ = 0.0f;
   float vel_ang_ = 0.0f;
 

--- a/confbot_driver/include/confbot_driver/confbot_driver.hpp
+++ b/confbot_driver/include/confbot_driver/confbot_driver.hpp
@@ -27,8 +27,6 @@
 
 #include "tf2_ros/static_transform_broadcaster.h"
 
-using namespace std::chrono_literals;
-
 namespace confbot_driver
 {
 
@@ -72,7 +70,8 @@ public:
     msg_.child_frame_id = "base_link";
 
     tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(shared_from_this());
-    timer_ = this->create_wall_timer(100ms, std::bind(&ConfbotDriver::update_odometry, this));
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(100), std::bind(&ConfbotDriver::update_odometry, this));
 
     cmd_vel_subscriber_ = this->create_subscription<geometry_msgs::msg::Twist>(
       "cmd_vel", std::bind(&ConfbotDriver::update_position, this, std::placeholders::_1));

--- a/confbot_driver/include/confbot_driver/twist_publisher.hpp
+++ b/confbot_driver/include/confbot_driver/twist_publisher.hpp
@@ -26,8 +26,6 @@
 
 #include "geometry_msgs/msg/twist.hpp"
 
-using namespace std::chrono_literals;
-
 namespace confbot_driver
 {
 
@@ -51,7 +49,7 @@ public:
     custom_qos_profile.depth = 7;
     pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", custom_qos_profile);
 
-    timer_ = this->create_wall_timer(100ms, publish_message);
+    timer_ = this->create_wall_timer(std::chrono::milliseconds(100), publish_message);
   }
 
   void init()

--- a/confbot_driver/include/confbot_driver/twist_publisher.hpp
+++ b/confbot_driver/include/confbot_driver/twist_publisher.hpp
@@ -1,3 +1,17 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONFBOT_DRIVER__TWIST_PUBLISHER_HPP_
 #define CONFBOT_DRIVER__TWIST_PUBLISHER_HPP_
 
@@ -5,6 +19,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/cmdline_parser.h"
@@ -19,7 +34,7 @@ namespace confbot_driver
 class TwistPublisher : public rclcpp::Node
 {
 public:
-  explicit TwistPublisher()
+  TwistPublisher()
   : Node("twist_publisher")
   {
     msg_ = std::make_shared<geometry_msgs::msg::Twist>();
@@ -39,7 +54,8 @@ public:
     timer_ = this->create_wall_timer(100ms, publish_message);
   }
 
-  void init() {
+  void init()
+  {
     // Setup callback for changes to parameters.
     auto parameter_change_cb =
       [this](std::vector<rclcpp::Parameter> parameters) -> rcl_interfaces::msg::SetParametersResult

--- a/confbot_driver/src/confbot_all.cpp
+++ b/confbot_driver/src/confbot_all.cpp
@@ -1,3 +1,19 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
 #include "confbot_driver/confbot_driver.hpp"
 #include "confbot_driver/twist_publisher.hpp"
 
@@ -18,4 +34,3 @@ int main(int argc, char * argv[])
   rclcpp::shutdown();
   return 0;
 }
-

--- a/confbot_driver/src/confbot_driver.cpp
+++ b/confbot_driver/src/confbot_driver.cpp
@@ -1,3 +1,19 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
 #include "confbot_driver/confbot_driver.hpp"
 
 int main(int argc, char * argv[])

--- a/confbot_driver/src/twist_publisher.cpp
+++ b/confbot_driver/src/twist_publisher.cpp
@@ -1,3 +1,19 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
 #include "confbot_driver/twist_publisher.hpp"
 
 int main(int argc, char * argv[])

--- a/confbot_sensors/CMakeLists.txt
+++ b/confbot_sensors/CMakeLists.txt
@@ -40,4 +40,9 @@ install(
   TARGETS confbot_laser
   DESTINATION lib/${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/confbot_sensors/include/confbot_sensors/confbot_laser.hpp
+++ b/confbot_sensors/include/confbot_sensors/confbot_laser.hpp
@@ -1,12 +1,26 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef CONFBOT_SENSORS__CONFBOT_LASER_HPP_
 #define CONFBOT_SENSORS__CONFBOT_LASER_HPP_
 
 #include <chrono>
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <thread>
-#include <cmath>
 
 #include "lifecycle_msgs/msg/transition.hpp"
 

--- a/confbot_sensors/include/confbot_sensors/confbot_laser.hpp
+++ b/confbot_sensors/include/confbot_sensors/confbot_laser.hpp
@@ -35,8 +35,6 @@
 
 #define DEG2RAD M_PI / 180.0
 
-using namespace std::chrono_literals;
-
 namespace confbot_sensors
 {
 
@@ -67,7 +65,7 @@ public:
     msg_ = std::make_shared<sensor_msgs::msg::LaserScan>();
     pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan");
     timer_ = this->create_wall_timer(
-      10ms, std::bind(&ConfbotLaser::publish, this));
+      std::chrono::milliseconds(10), std::bind(&ConfbotLaser::publish, this));
 
     msg_->header.frame_id = "laser_link";
 

--- a/confbot_sensors/src/confbot_laser.cpp
+++ b/confbot_sensors/src/confbot_laser.cpp
@@ -1,3 +1,19 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
 #include "confbot_sensors/confbot_laser.hpp"
 
 int main(int argc, char * argv[])

--- a/confbot_tools/confbot_tools/safe_zone_publisher.py
+++ b/confbot_tools/confbot_tools/safe_zone_publisher.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 
 import rclpy

--- a/confbot_tools/confbot_tools/safe_zone_publisher.py
+++ b/confbot_tools/confbot_tools/safe_zone_publisher.py
@@ -62,7 +62,7 @@ class SafeZonePublisher(Node):
         # https://www.yobi3d.com/
         # https://www.yobi3d.com/v/tivZ0KYsrZ/Shark_t.stl
         # mesh is licensed under CC-BY
-        self.shark.mesh_resource = 'file:///Users/karsten/workspace/osrf/roscon2018_ws/src/roscon2018/confbot_description/meshes/Shark_t.stl'
+        self.shark.mesh_resource = 'file:///Users/karsten/workspace/osrf/roscon2018_ws/src/roscon2018/confbot_description/meshes/Shark_t.stl'  # noqa E501
 
     def timer_callback(self):
 

--- a/confbot_tools/confbot_tools/safe_zone_publisher_hacked.py
+++ b/confbot_tools/confbot_tools/safe_zone_publisher_hacked.py
@@ -1,10 +1,25 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
+
+from geometry_msgs.msg import Twist
 
 import rclpy
 from rclpy.clock import Clock
 from rclpy.node import Node
 
-from geometry_msgs.msg import Twist
 from visualization_msgs.msg import Marker
 
 

--- a/confbot_tools/confbot_tools/safe_zone_publisher_hacked.py
+++ b/confbot_tools/confbot_tools/safe_zone_publisher_hacked.py
@@ -65,7 +65,7 @@ class SafeZonePublisher(Node):
         # https://www.yobi3d.com/
         # https://www.yobi3d.com/v/tivZ0KYsrZ/Shark_t.stl
         # mesh is licensed under CC-BY
-        self.shark.mesh_resource = 'file:///Users/karsten/workspace/osrf/roscon2018_ws/src/roscon2018/confbot_description/meshes/Shark_t.stl'
+        self.shark.mesh_resource = 'file:///Users/karsten/workspace/osrf/roscon2018_ws/src/roscon2018/confbot_description/meshes/Shark_t.stl'  # noqa E501
 
     def timer_callback(self):
 

--- a/confbot_tools/test/test_copyright.py
+++ b/confbot_tools/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.'])
+    assert rc == 0, 'Found errors'

--- a/confbot_tools/test/test_flake8.py
+++ b/confbot_tools/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/confbot_tools/test/test_pep257.py
+++ b/confbot_tools/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.'])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
Add the linter test and fix the violations.

One violation is ignored instead of fixed: the mesh file url in https://github.com/Karsten1987/roscon2018/compare/add_linter_tests?expand=1#diff-7cddae14bed310d6f5c07d7ab190ca15R65

Note: the CI is testing the master branch and not the PR branch so it would not show the new test results
Note2: ament_flake8 is [currently broken in Crystal](https://github.com/ament/ament_lint/pull/124), so the flake8 tests will fail once this PR is merged, hopefully it'll be fixed in the next patch release