### PR TITLE
don't crash on non double speed parameter

### DIFF
--- a/confbot_driver/src/nodes/twist_publisher.cpp
+++ b/confbot_driver/src/nodes/twist_publisher.cpp
@@ -52,17 +52,34 @@ TwistPublisher::TwistPublisher(rclcpp::NodeOptions options)
       for (auto parameter : parameters) {
         if (parameter.get_name() == "speed") {
           if (rclcpp::ParameterType::PARAMETER_NOT_SET == parameter.get_type()) {
-            RCLCPP_INFO(this->get_logger(),
+            RCLCPP_WARN(this->get_logger(),
               "cannot delete '%s' as it is a required parameter",
               parameter.get_name().c_str()
             );
             result.successful = false;
-          } else {
+          } else if (rclcpp::ParameterType::PARAMETER_DOUBLE == parameter.get_type()) {
             RCLCPP_INFO(this->get_logger(),
               "set parameter '%s' to '%f'",
               parameter.get_name().c_str(),
               parameter.as_double());
             speed_ = parameter.as_double();
+          } else if (rclcpp::ParameterType::PARAMETER_INTEGER == parameter.get_type()) {
+            RCLCPP_INFO(this->get_logger(),
+              "set parameter '%s' to '%f'",
+              parameter.get_name().c_str(),
+              static_cast<double>(parameter.as_int())
+            );
+            speed_ = static_cast<double>(parameter.as_int());
+          } else {
+            RCLCPP_WARN(this->get_logger(),
+              "'%s' is a numerical type of type 'double', the provided type '%s' is not supported, "
+              "compatible types are '%s' and '%s'",
+              parameter.get_name().c_str(),
+              to_string(parameter.get_type()).c_str(),
+              to_string(rclcpp::ParameterType::PARAMETER_DOUBLE).c_str(),
+              to_string(rclcpp::ParameterType::PARAMETER_INTEGER).c_str()
+            );
+            result.successful = false;
           }
         }
       }


### PR DESCRIPTION
- support int parameter value and store it as double
- reject parameter change for other types
- print rejected parameter messages as warning and not info

Current behavior:
`ros2 param set /twist_publisher speed 1`
```
[twist_publisher-3] terminate called after throwing an instance of 'rclcpp::ParameterTypeException'
[twist_publisher-3]   what():  expected [double] got [integer]
[ERROR] [twist_publisher-3]: process has died [pid 22603, exit code -6, cmd '/media/mikatchou/ROS/ros2/roscon2019/roscon2019_ws/install/lib/confbot_driver/twist_publisher'].
```

With this PR:
`ros2 param set /twist_publisher speed 1`
```
[twist_publisher-3] [INFO] [twist_publisher]: set parameter 'speed' to '1.000000'
```

`ros2 param set /twist_publisher speed a_string`
```
[twist_publisher-3] [WARN] [twist_publisher]: 'speed' is a numerical type of type 'double', the provided type 'string' is not supported, compatible types are 'double' and 'integer'
```