### PR TITLE
Dashing ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
 
 matrix:
   include:
-    # - script: .ros2ci/travis.bash crystal
+    - script: .ros2ci/travis.bash dashing
     - script: .ros2ci/travis.bash nightly

--- a/confbot_tools/setup.py
+++ b/confbot_tools/setup.py
@@ -8,6 +8,8 @@ setup(
     version='0.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
     ],
     install_requires=['setuptools'],
@@ -16,14 +18,14 @@ setup(
     author_email='karsten.knese@googlemail.com',
     maintainer='Karsten Knese',
     maintainer_email='karsten.knese@googlemail.com',
-    keywords=['confbot'],
+    keywords=['confbot', 'ROS'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
-    license='Apache 2.0',
+    license='Apache License, Version 2.0',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Enable CI for ROS2 dashing.

**Do not merge yet** as CI fails on master and dashing ~~is now installing opensplice by default and the action package fails to generate the messages for opensplice.~~

Opensplice issue worked around in https://github.com/mikaelarguedas/ros2ci/pull/17 and fixed upstream at https://github.com/ros2-gbp/rmw_implementation-release/pull/2

~~pytest failure still present~~

pytest failure reported upstream https://github.com/ros2/ros2/issues/722
worked around in https://github.com/mikaelarguedas/ros2ci/pull/18 and addressed in https://github.com/osrf/docker_images/pull/272

CI is now green on both nightly and dashing :tada: 