### PR TITLE
specify history depth explicitly to avoid rclpy warnings

### DIFF
--- a/confbot_tools/confbot_tools/safe_zone_publisher.py
+++ b/confbot_tools/confbot_tools/safe_zone_publisher.py
@@ -29,8 +29,8 @@ class SafeZonePublisher(Node):
     def __init__(self):
         super().__init__('safe_zone_publisher')
 
-        self.pub = self.create_publisher(Marker, 'safe_zone')
-        self.shark_pub = self.create_publisher(Marker, 'danger_zone')
+        self.pub = self.create_publisher(Marker, 'safe_zone', 10)
+        self.shark_pub = self.create_publisher(Marker, 'danger_zone', 10)
         timer_period = 1.0
         self.tmr = self.create_timer(timer_period, self.timer_callback)
 

--- a/confbot_tools/confbot_tools/safe_zone_publisher_hacked.py
+++ b/confbot_tools/confbot_tools/safe_zone_publisher_hacked.py
@@ -31,9 +31,9 @@ class SafeZonePublisher(Node):
     def __init__(self):
         super().__init__('safe_zone_publisher')
 
-        self.pub = self.create_publisher(Marker, 'safe_zone')
-        self.hacked_pub = self.create_publisher(Twist, 'cmd_vel')
-        self.shark_pub = self.create_publisher(Marker, 'danger_zone')
+        self.pub = self.create_publisher(Marker, 'safe_zone', 10)
+        self.hacked_pub = self.create_publisher(Twist, 'cmd_vel', 10)
+        self.shark_pub = self.create_publisher(Marker, 'danger_zone', 10)
         timer_period = 1.0
         self.tmr = self.create_timer(timer_period, self.timer_callback)
 


### PR DESCRIPTION
Otherwise we get some warnings like:

```
[safe_zone_publisher-2] /opt/ros/dashing/lib/python3.6/site-packages/rclpy/node.py:1030: UserWarning: Pass an explicit 'qos_profile' argument
```
Similar to https://github.com/ros2/demos/pull/334/


Value of `10` is picked to match the previous default. There doesnt seem to be a define for it:
https://github.com/ros2/rmw/blob/a54e25b64eeeb95b5437f4c5d47279f856f291be/rmw/include/rmw/qos_profiles.h#L54