### PR TITLE
Add repos nightly only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ services:
 
 install:
   - git clone --quiet --depth 1 https://github.com/mikaelarguedas/ros2ci.git .ros2ci
-  - cp additional_repos.repos .ros2ci/
 
 matrix:
   include:
     - script: .ros2ci/travis.bash dashing
-    - script: .ros2ci/travis.bash nightly
+    - script:
+      - cp additional_repos.repos .ros2ci/
+      - .ros2ci/travis.bash nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ install:
 
 matrix:
   include:
-    - script: .ros2ci/travis.bash dashing
-    - script:
+    - env: JOB_TYPE=dashing
+      script: .ros2ci/travis.bash dashing
+    - env: JOB_TYPE=nightly
+      script:
       - cp additional_repos.repos .ros2ci/
       - .ros2ci/travis.bash nightly


### PR DESCRIPTION
The packages in additional_repos.repos are all available from debs,
So we should build them from source only on the nightly CI but use the
debs on the dashing one


With this change, dashing CI time goes from ~10min to ~5min

https://github.com/Karsten1987/roscon2018/commit/34ed95e512a571d9e699c20c4ece159b9d5da9d8 adds a JOB_TYPE env var to see on travis which job is which