### PR TITLE
[travis] reuse JOB_TYPE env var instead of writing version explicitely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
 matrix:
   include:
     - env: JOB_TYPE=dashing
-      script: .ros2ci/travis.bash dashing
+      script: .ros2ci/travis.bash $JOB_TYPE
     - env: JOB_TYPE=nightly
       script:
       - cp additional_repos.repos .ros2ci/
-      - .ros2ci/travis.bash nightly
+      - .ros2ci/travis.bash $JOB_TYPE


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>